### PR TITLE
96 melhorar criação de carrinho

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -10,7 +10,7 @@ import { Types } from 'mongoose';
 
 describe('AuthService', () => {
   let service: AuthService;
-  const findOneMockFn = jest.fn();
+  const findOneOrReturnNullMockFn = jest.fn();
   const signMockFn = jest.fn();
   const userModelMockFn = jest.fn();
   const bcryptSpy = jest.spyOn(bcrypt, 'compare');
@@ -24,7 +24,7 @@ describe('AuthService', () => {
         {
           provide: UsersService,
           useValue: {
-            findOne: findOneMockFn,
+            findOneOrReturnNull: findOneOrReturnNullMockFn,
           },
         },
         {
@@ -55,7 +55,7 @@ describe('AuthService', () => {
       roles: [Role.Cisab],
     };
 
-    findOneMockFn.mockReturnValue(Promise.resolve(user));
+    findOneOrReturnNullMockFn.mockReturnValue(Promise.resolve(user));
     bcryptSpy.mockReturnValue(Promise.resolve(true));
 
     const validateUser = await service.validateUser('carlos', 'test');
@@ -65,7 +65,7 @@ describe('AuthService', () => {
   });
 
   it('should return null', async () => {
-    findOneMockFn.mockReturnValue({});
+    findOneOrReturnNullMockFn.mockReturnValue({});
     bcryptSpy.mockReturnValue(Promise.resolve(false));
     const validateUser = await service.validateUser('carlos', 'test');
 
@@ -100,7 +100,7 @@ describe('AuthService', () => {
       properties: {},
     };
 
-    findOneMockFn.mockReturnValue(Promise.resolve(user));
+    findOneOrReturnNullMockFn.mockReturnValue(Promise.resolve(user));
 
     const res = await service.profile({
       email: 'carlos',

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -29,7 +29,7 @@ export class AuthService {
   ) {}
 
   async validateUser(email: string, password: string) {
-    const user = await this.usersService.findOne({ email });
+    const user = await this.usersService.findOneOrReturnNull({ email });
 
     if (!user) return null;
 
@@ -64,7 +64,9 @@ export class AuthService {
   }
 
   async profile(payload: Payload) {
-    const user = await this.usersService.findOne({ _id: payload.sub });
+    const user = await this.usersService.findOneOrReturnNull({
+      _id: payload.sub,
+    });
     return {
       _id: user._id,
       email: user.email,

--- a/src/carts/carts.controller.ts
+++ b/src/carts/carts.controller.ts
@@ -14,12 +14,13 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '../auth/role.enum';
 import { Roles } from '../auth/roles.decorator';
 import { CartsRequest } from './dto/request/carts-request.dto';
-import { ApiBody, ApiOperation } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetCartResponse } from './dto/response/get-cart-response.dto';
 import { CartsService } from './carts.service';
 import { Payload } from 'src/auth/auth.service';
 
 @Controller('carts')
+@ApiTags('carts')
 export class CartsController {
   private readonly logger = new Logger(CartsController.name);
 

--- a/src/carts/carts.controller.ts
+++ b/src/carts/carts.controller.ts
@@ -17,8 +17,8 @@ import { CartsRequest } from './dto/request/carts-request.dto';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetCartResponse } from './dto/response/get-cart-response.dto';
 import { CartsService } from './carts.service';
-import { Payload } from 'src/auth/auth.service';
-import { ParseObjectIdPipe } from 'src/pipes/parse-objectid.pipe';
+import { Payload } from '../auth/auth.service';
+import { ParseObjectIdPipe } from '../pipes/parse-objectid.pipe';
 
 @Controller('carts')
 @ApiTags('carts')

--- a/src/carts/carts.controller.ts
+++ b/src/carts/carts.controller.ts
@@ -18,6 +18,7 @@ import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetCartResponse } from './dto/response/get-cart-response.dto';
 import { CartsService } from './carts.service';
 import { Payload } from 'src/auth/auth.service';
+import { ParseObjectIdPipe } from 'src/pipes/parse-objectid.pipe';
 
 @Controller('carts')
 @ApiTags('carts')
@@ -50,7 +51,7 @@ export class CartsController {
   @Roles(Role.Employee, Role.Manager)
   @Get(':demand_id')
   getCart(
-    @Param('demand_id') demandId: string,
+    @Param('demand_id', ParseObjectIdPipe) demandId: string,
     @Request() req,
   ): Promise<GetCartResponse> {
     try {
@@ -69,7 +70,10 @@ export class CartsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.Employee, Role.Manager)
   @Post(':demand_id/close')
-  closeCart(@Param('demand_id') demandId: string, @Request() req) {
+  closeCart(
+    @Param('demand_id', ParseObjectIdPipe) demandId: string,
+    @Request() req,
+  ) {
     try {
       const userPayload = req.user as Payload;
       return this.cartsService.close(userPayload.county_id, demandId);

--- a/src/carts/carts.service.spec.ts
+++ b/src/carts/carts.service.spec.ts
@@ -17,7 +17,7 @@ describe('CartsService', () => {
   const productFindAllMockFn = jest.fn();
   const demandsFindOneMockFn = jest.fn();
   const countiesFindOneMockFn = jest.fn();
-  const usersFindOneOrReturnNullMockFn = jest.fn();
+  const usersFindOneMockFn = jest.fn();
   const cacheUpsertMockFn = jest.fn();
   const cacheGetMockFn = jest.fn();
   const closeMongoMockFn = jest.fn();
@@ -61,7 +61,7 @@ describe('CartsService', () => {
         {
           provide: UsersService,
           useValue: {
-            findOneOrReturnNull: usersFindOneOrReturnNullMockFn,
+            findOne: usersFindOneMockFn,
           },
         },
       ],
@@ -111,7 +111,7 @@ describe('CartsService', () => {
     demandsFindOneMockFn.mockReturnValue(
       Promise.resolve({ name: 'Demand name' }),
     );
-    usersFindOneOrReturnNullMockFn.mockReturnValue(
+    usersFindOneMockFn.mockReturnValue(
       Promise.resolve({ name: 'Name', surname: 'Surname' }),
     );
     countiesFindOneMockFn.mockReturnValue(
@@ -204,7 +204,7 @@ describe('CartsService', () => {
     demandsFindOneMockFn.mockReturnValue(
       Promise.resolve({ name: 'Demand name', products: [{ _id: '1a' }] }),
     );
-    usersFindOneOrReturnNullMockFn.mockReturnValue(
+    usersFindOneMockFn.mockReturnValue(
       Promise.resolve({ name: 'Name', surname: 'Surname' }),
     );
     countiesFindOneMockFn.mockReturnValue(

--- a/src/carts/carts.service.spec.ts
+++ b/src/carts/carts.service.spec.ts
@@ -17,7 +17,7 @@ describe('CartsService', () => {
   const productFindAllMockFn = jest.fn();
   const demandsFindOneMockFn = jest.fn();
   const countiesFindOneMockFn = jest.fn();
-  const usersFindOneMockFn = jest.fn();
+  const usersFindOneOrReturnNullMockFn = jest.fn();
   const cacheUpsertMockFn = jest.fn();
   const cacheGetMockFn = jest.fn();
   const closeMongoMockFn = jest.fn();
@@ -61,7 +61,7 @@ describe('CartsService', () => {
         {
           provide: UsersService,
           useValue: {
-            findOne: usersFindOneMockFn,
+            findOneOrReturnNull: usersFindOneOrReturnNullMockFn,
           },
         },
       ],
@@ -111,7 +111,7 @@ describe('CartsService', () => {
     demandsFindOneMockFn.mockReturnValue(
       Promise.resolve({ name: 'Demand name' }),
     );
-    usersFindOneMockFn.mockReturnValue(
+    usersFindOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ name: 'Name', surname: 'Surname' }),
     );
     countiesFindOneMockFn.mockReturnValue(
@@ -204,7 +204,7 @@ describe('CartsService', () => {
     demandsFindOneMockFn.mockReturnValue(
       Promise.resolve({ name: 'Demand name', products: [{ _id: '1a' }] }),
     );
-    usersFindOneMockFn.mockReturnValue(
+    usersFindOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ name: 'Name', surname: 'Surname' }),
     );
     countiesFindOneMockFn.mockReturnValue(

--- a/src/carts/carts.service.ts
+++ b/src/carts/carts.service.ts
@@ -8,7 +8,6 @@ import { CartsCacheRepository } from './carts.cache.repository';
 import { CartsMongoRepository } from './carts.mongo.repository';
 import { CartDto, CartProductDto, CartProductIdDto } from './dto/cart.dto';
 import { CartsRequest } from './dto/request/carts-request.dto';
-import { GetCartResponse } from './dto/response/get-cart-response.dto';
 
 @Injectable()
 export class CartsService {
@@ -67,7 +66,7 @@ export class CartsService {
     );
 
     const { name: userName, surname: userSurname } =
-      await this.usersService.findOne({ _id: userId });
+      await this.usersService.findOneOrReturnNull({ _id: userId });
 
     const fullName = `${userName} ${userSurname}`;
 
@@ -131,7 +130,7 @@ export class CartsService {
     );
 
     const { name: userName, surname: userSurname } =
-      await this.usersService.findOne({ _id: user_id });
+      await this.usersService.findOneOrReturnNull({ _id: user_id });
 
     const fullName = `${userName} ${userSurname}`;
 

--- a/src/carts/carts.service.ts
+++ b/src/carts/carts.service.ts
@@ -66,7 +66,7 @@ export class CartsService {
     );
 
     const { name: userName, surname: userSurname } =
-      await this.usersService.findOneOrReturnNull({ _id: userId });
+      await this.usersService.findOne({ _id: userId });
 
     const fullName = `${userName} ${userSurname}`;
 
@@ -130,7 +130,7 @@ export class CartsService {
     );
 
     const { name: userName, surname: userSurname } =
-      await this.usersService.findOneOrReturnNull({ _id: user_id });
+      await this.usersService.findOne({ _id: user_id });
 
     const fullName = `${userName} ${userSurname}`;
 

--- a/src/carts/dto/request/carts-request.dto.ts
+++ b/src/carts/dto/request/carts-request.dto.ts
@@ -1,17 +1,26 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsNumber, ValidateNested } from 'class-validator';
+import { IsObjectId } from '../../../libs/class-validator-mongo-object-id';
 
 export class CartsProductRequest {
   @ApiProperty()
+  @IsObjectId()
   product_id: string;
 
   @ApiProperty()
+  @IsNumber()
   quantity: number;
 }
 
 export class CartsRequest {
   @ApiProperty()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CartsProductRequest)
   products: CartsProductRequest[];
 
   @ApiProperty()
+  @IsObjectId()
   demand_id: string;
 }

--- a/src/carts/dto/response/get-cart-response.dto.ts
+++ b/src/carts/dto/response/get-cart-response.dto.ts
@@ -1,23 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class GetProductIdsResponse {
+  @ApiProperty()
+  product_id: string;
+
+  @ApiProperty()
+  quantity: number;
+}
+
 class GetCartMeasurementResponse {
+  @ApiProperty()
   name: string;
+
+  @ApiProperty()
   value: string;
+
+  @ApiProperty()
   unit: string;
 }
 
 class GetCartProductResponse {
+  @ApiProperty()
   _id: string;
+
+  @ApiProperty()
   name: string;
+
+  @ApiProperty()
   norms: string[];
+
+  @ApiProperty()
   categories: string[];
+
+  @ApiProperty()
   photo_url: string;
+
+  @ApiProperty({ type: () => [GetCartMeasurementResponse] })
   measurements: GetCartMeasurementResponse[];
+
+  @ApiProperty()
   quantity: number;
 }
 
 export class GetCartResponse {
+  @ApiProperty()
   _id: string;
+
+  @ApiProperty()
   state: string;
+
+  @ApiProperty({ type: () => [GetCartProductResponse] })
   products: GetCartProductResponse[];
+
+  @ApiProperty({ type: () => [GetProductIdsResponse] })
+  product_ids: GetProductIdsResponse[];
+
+  @ApiProperty()
   user_id: string;
+
+  @ApiProperty()
   updated_on: Date;
 }

--- a/src/counties/counties.service.spec.ts
+++ b/src/counties/counties.service.spec.ts
@@ -86,7 +86,7 @@ describe('CountiesService', () => {
   const findEmployeeMockFn = jest.fn();
   const updateEmployeeMockFn = jest.fn();
   const removeEmployeeMockFn = jest.fn();
-  const findOneEmployeeMock = jest.fn();
+  const findOneOrReturnNullEmployeeMock = jest.fn();
   startTransactionMockFn.mockReturnValue(
     Promise.resolve({
       abortTransaction: jest.fn(),
@@ -114,7 +114,7 @@ describe('CountiesService', () => {
       find: findEmployeeMockFn,
       update: updateEmployeeMockFn,
       remove: removeEmployeeMockFn,
-      findOne: findOneEmployeeMock,
+      findOneOrReturnNull: findOneOrReturnNullEmployeeMock,
       removeMany: removeManyUsersMockFn,
     };
 
@@ -277,7 +277,7 @@ describe('CountiesService', () => {
     const idString = '63599affb40135010840911b';
     const idStub = new Types.ObjectId(idString);
 
-    findOneEmployeeMock.mockReturnValue({});
+    findOneOrReturnNullEmployeeMock.mockReturnValue({});
 
     const res = await service.isManagerActive(idStub);
 
@@ -288,7 +288,7 @@ describe('CountiesService', () => {
     const idString = '63599affb40135010840911b';
     const idStub = new Types.ObjectId(idString);
 
-    findOneEmployeeMock.mockReturnValue({ password: '12a' });
+    findOneOrReturnNullEmployeeMock.mockReturnValue({ password: '12a' });
 
     const res = await service.isManagerActive(idStub);
 
@@ -307,7 +307,7 @@ describe('CountiesService', () => {
       properties: new Map<string, string>(),
     };
 
-    findOneEmployeeMock.mockReturnValue(Promise.resolve(user));
+    findOneOrReturnNullEmployeeMock.mockReturnValue(Promise.resolve(user));
     const res = await service.updateManagerPassword(idStub, 'password');
 
     expect(res).toBeTruthy();
@@ -317,7 +317,7 @@ describe('CountiesService', () => {
     const idString = '63599affb40135010840911b';
     const idStub = new Types.ObjectId(idString);
 
-    findOneEmployeeMock.mockImplementation(() => {
+    findOneOrReturnNullEmployeeMock.mockImplementation(() => {
       throw new Error();
     });
 

--- a/src/counties/counties.service.ts
+++ b/src/counties/counties.service.ts
@@ -208,7 +208,7 @@ export class CountiesService {
   }
 
   async isManagerActive(id: Types.ObjectId) {
-    const user = await this.usersService.findOne({ _id: id });
+    const user = await this.usersService.findOneOrReturnNull({ _id: id });
 
     if (user.password) return true;
     return false;
@@ -217,7 +217,7 @@ export class CountiesService {
   async updateManagerPassword(userId: Types.ObjectId, password: string) {
     try {
       const { _id, name, surname, email, roles, properties } =
-        await this.usersService.findOne({ _id: userId });
+        await this.usersService.findOneOrReturnNull({ _id: userId });
 
       await this.usersService.update({
         _id,

--- a/src/forget-password/forget-password.service.spec.ts
+++ b/src/forget-password/forget-password.service.spec.ts
@@ -9,7 +9,7 @@ describe('ForgetPasswordService', () => {
   let service: ForgetPasswordService;
   const startTransactionMockFn = jest.fn();
 
-  const findOneMockFn = jest.fn();
+  const findOneOrReturnNullMockFn = jest.fn();
   const createMockFn = jest.fn();
   const emitMockFn = jest.fn();
   const findOneForgetPasswordMockFn = jest.fn();
@@ -32,7 +32,7 @@ describe('ForgetPasswordService', () => {
         {
           provide: UsersService,
           useValue: {
-            findOne: findOneMockFn,
+            findOneOrReturnNull: findOneOrReturnNullMockFn,
             update: updateMockFn,
           },
         },
@@ -59,7 +59,7 @@ describe('ForgetPasswordService', () => {
   });
 
   it('should run forget password use case', async () => {
-    findOneMockFn.mockReturnValue(
+    findOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ _id: '12', email: 'contact@czar.dev' }),
     );
 
@@ -73,7 +73,7 @@ describe('ForgetPasswordService', () => {
   it('should throw exception in forget password', async () => {
     class TestError extends Error {}
 
-    findOneMockFn.mockImplementation(() => {
+    findOneOrReturnNullMockFn.mockImplementation(() => {
       throw new TestError();
     });
 
@@ -116,7 +116,7 @@ describe('ForgetPasswordService', () => {
       Promise.resolve({ _id: '1a', userId: 'b1' }),
     );
 
-    findOneMockFn.mockReturnValue(
+    findOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ password: 'password', email: 'contact@czar.dev' }),
     );
 
@@ -146,7 +146,7 @@ describe('ForgetPasswordService', () => {
       Promise.resolve({ _id: '1a', userId: 'b1' }),
     );
 
-    findOneMockFn.mockReturnValue(Promise.resolve());
+    findOneOrReturnNullMockFn.mockReturnValue(Promise.resolve());
     sortMockFn.mockReturnValue(Promise.resolve([]));
 
     try {
@@ -163,7 +163,7 @@ describe('ForgetPasswordService', () => {
       Promise.resolve({ _id: '1a', userId: 'b1' }),
     );
 
-    findOneMockFn.mockReturnValue(
+    findOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ password: 'password', email: 'contact@czar.dev' }),
     );
 
@@ -187,7 +187,7 @@ describe('ForgetPasswordService', () => {
       Promise.resolve(forgetPassword),
     );
 
-    findOneMockFn.mockReturnValue(
+    findOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ password: 'password', email: 'contact@czar.dev' }),
     );
 
@@ -208,7 +208,7 @@ describe('ForgetPasswordService', () => {
       Promise.resolve(forgetPassword),
     );
 
-    findOneMockFn.mockReturnValue(
+    findOneOrReturnNullMockFn.mockReturnValue(
       Promise.resolve({ password: 'password', email: 'contact@czar.dev' }),
     );
 

--- a/src/forget-password/forget-password.service.ts
+++ b/src/forget-password/forget-password.service.ts
@@ -28,7 +28,7 @@ export class ForgetPasswordService {
     const session = await this.forgetPasswordRepository.startTransaction();
 
     try {
-      const user = await this.usersService.findOne({ email });
+      const user = await this.usersService.findOneOrReturnNull({ email });
 
       if (!user) throw new NotFoundException();
 
@@ -69,7 +69,7 @@ export class ForgetPasswordService {
 
     await this.validateForgetPassword(forgetPassword);
 
-    const user = await this.usersService.findOne({
+    const user = await this.usersService.findOneOrReturnNull({
       _id: forgetPassword.userId,
     });
 

--- a/src/libs/class-validator-mongo-object-id.spec.ts
+++ b/src/libs/class-validator-mongo-object-id.spec.ts
@@ -1,0 +1,9 @@
+import { IsObjectId } from './class-validator-mongo-object-id';
+
+describe('is object id', () => {
+  it('should return a decorator', () => {
+    const res = IsObjectId({});
+
+    expect(res).toBeDefined();
+  });
+});

--- a/src/libs/class-validator-mongo-object-id.ts
+++ b/src/libs/class-validator-mongo-object-id.ts
@@ -1,0 +1,29 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { Types as MongooseTypes } from 'mongoose';
+
+export function IsObjectId(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  validationOptions = {
+    ...validationOptions,
+    message: 'ObjectId is not valid.',
+  };
+
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      name: 'isObjectId',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          return MongooseTypes.ObjectId.isValid(value);
+        },
+      },
+    });
+  };
+}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -312,4 +312,22 @@ describe('User Service', () => {
       expect(err).toBeInstanceOf(Error);
     }
   });
+
+  it('should find one user', async () => {
+    const user = {
+      _id: '1',
+      email: 'carlos@czar.dev',
+      password: 'changeme',
+      roles: [Role.Cisab],
+      properties: new Map<string, string>(),
+    };
+
+    findOneMockFn.mockReturnValue(Promise.resolve(user));
+
+    const expectedUser = await service.findOne({
+      email: 'carlos@czar.dev',
+    });
+
+    expect(expectedUser).toEqual(user);
+  });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -55,7 +55,9 @@ describe('User Service', () => {
 
     findOneMockFn.mockReturnValue(Promise.resolve(user));
 
-    const expectedUser = await service.findOne({ email: 'carlos@czar.dev' });
+    const expectedUser = await service.findOneOrReturnNull({
+      email: 'carlos@czar.dev',
+    });
 
     expect(expectedUser).toEqual(user);
   });
@@ -158,7 +160,9 @@ describe('User Service', () => {
     findOneMockFn.mockImplementation(() => {
       throw new Error();
     });
-    const res = await service.findOne({ email: 'crazyemail@undefined.com' });
+    const res = await service.findOneOrReturnNull({
+      email: 'crazyemail@undefined.com',
+    });
 
     expect(res).toBeNull();
   });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -19,7 +19,7 @@ export class UsersService {
 
   constructor(private readonly usersRepository: UsersRepository) {}
 
-  async findOne(filterQuery: FilterQuery<User>) {
+  async findOneOrReturnNull(filterQuery: FilterQuery<User>) {
     try {
       const user = await this.usersRepository.findOne(filterQuery);
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -32,6 +32,10 @@ export class UsersService {
     }
   }
 
+  async findOne(filterQuery: FilterQuery<User>) {
+    return this.usersRepository.findOne(filterQuery);
+  }
+
   async find(filterQuery: FilterQuery<User>) {
     try {
       return await this.usersRepository.find(filterQuery);


### PR DESCRIPTION
Feitos:

- Quando usuário não tem nome, da Internal Server Error
- Swagger sem contratos
- Verificação dos DTOs de request do carrinho
- Mandar um object id invalido da erro 500

Eu também tive que alterar o UsersService.findOne para findOneOrReturnNull. Como ele retornava null, dava um excessão pois tentava pegar o nome de null. Então para resolver isso, eu criei uma outro método chamado findOne em que ele retorna undefined. Se o usuário não tiver nome, ele vai como "undefined undefined".